### PR TITLE
Remove unneeded code

### DIFF
--- a/reconftw.sh
+++ b/reconftw.sh
@@ -50,11 +50,6 @@ start(){
 		mkdir -p $called_fn_dir
 	fi
 
-	if [ ! -d "$dir" ]
-	then
-		mkdir -p $dir
-	fi
-
 	if [ -n "$list" ]
 	then
 		cp $list $dir/${domain}_probed.txt


### PR DESCRIPTION
The removed if would never execute since `mkdir -p $called_fn_dir` will always create the `$dir` directory.

Not a big deal, just a small cleanup.