### PR TITLE
Fix install.sh missing dependencies and apt hang

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -55,6 +55,7 @@ repos["OpenRedireX"]="devanshbatham/OpenRedireX"
 repos["GitDorker"]="obheda12/GitDorker"
 repos["testssl"]="drwetter/testssl.sh"
 repos["ip2provider"]="oldrho/ip2provider"
+repos["uddup"]="rotemreiss/uddup"
 
 dir=${tools}
 
@@ -83,9 +84,9 @@ fi
 
 install_apt(){
     eval $SUDO apt update -y $DEBUG_STD
-    eval $SUDO apt install chromium-browser -y $DEBUG_STD
-    eval $SUDO apt install chromium -y $DEBUG_STD
-    eval $SUDO apt install python3 python3-pip gcc build-essential ruby git curl libpcap-dev wget zip python3-dev pv dnsutils libssl-dev libffi-dev libxml2-dev libxslt1-dev zlib1g-dev nmap jq apt-transport-https lynx tor medusa -y $DEBUG_STD
+    eval $SUDO DEBIAN_FRONTEND="noninteractive" apt install chromium-browser -y $DEBUG_STD
+    eval $SUDO DEBIAN_FRONTEND="noninteractive" apt install chromium -y $DEBUG_STD
+    eval $SUDO DEBIAN_FRONTEND="noninteractive" apt install python3 python3-pip gcc build-essential ruby git curl libpcap-dev wget zip python3-dev pv dnsutils libssl-dev libffi-dev libxml2-dev libxslt1-dev zlib1g-dev nmap jq apt-transport-https lynx tor medusa -y $DEBUG_STD
     eval $SUDO systemctl enable tor $DEBUG_STD
 }
 
@@ -215,6 +216,8 @@ for repo in "${!repos[@]}"; do
     fi
     if [ -s "setup.py" ]; then
         eval $SUDO python3 setup.py install $DEBUG_STD
+    elif [ -s "requirements.txt" ]; then
+        eval pip3 install -U -r requirements.txt $DEBUG_STD
     fi
     if [ "massdns" = "$repo" ]; then
             eval make $DEBUG_STD && strip -s bin/massdns && eval $SUDO cp bin/massdns /usr/bin/ $DEBUG_ERROR

--- a/reconftw.sh
+++ b/reconftw.sh
@@ -96,6 +96,7 @@ function tools_installed(){
 	type -P dalfox &>/dev/null || { printf "${bred} [*] dalfox		[NO]${reset}\n${reset}"; allinstalled=false;}
 	type -P puredns &>/dev/null || { printf "${bred} [*] puredns		[NO]${reset}\n${reset}"; allinstalled=false;}
 	type -P unimap &>/dev/null || { printf "${bred} [*] unimap		[NO]${reset}\n${reset}"; allinstalled=false;}
+	type -P uddup &>/dev/null || { printf "${bred} [*] uddup		[NO]${reset}\n${reset}"; allinstalled=false;}
 
 	if [ "${allinstalled}" = true ]; then
 		printf "${bgreen} Good! All installed! ${reset}\n\n"


### PR DESCRIPTION
The uddup repo was missing from the install.sh script which prevented the
urlchecks from correctly processing URLs if it wasn't installed manually.

In addition, the requirements for the ip2provider python application
were not being installed because the repo doesn't contain a setup.py file.
The install.sh script will now look for a requirements.txt file if a setup.py
file isn't present and install the dependencies using pip3.

Finally, the install.sh script could hang during the install_apt() function when
apt-get expects user interaction, even though the -y argument is provided.
I added DEBIAN_FRONTEND="noninteractive" in front of the calls to
apt install to help prevent this.

Tested on fresh Ubuntu 18.04, Ubuntu 20.04 and Debian 10 docker images.

Resolves #286
Resolves #287
Resolves #289