### PR TITLE
Fix possible hang during install_apt()

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -83,9 +83,9 @@ fi
 
 install_apt(){
     eval $SUDO apt update -y $DEBUG_STD
-    eval $SUDO apt install chromium-browser -y $DEBUG_STD
-    eval $SUDO apt install chromium -y $DEBUG_STD
-    eval $SUDO apt install python3 python3-pip gcc build-essential ruby git curl libpcap-dev wget zip python3-dev pv dnsutils libssl-dev libffi-dev libxml2-dev libxslt1-dev zlib1g-dev nmap jq apt-transport-https lynx tor medusa -y $DEBUG_STD
+    eval $SUDO DEBIAN_FRONTEND="noninteractive" apt install chromium-browser -y $DEBUG_STD
+    eval $SUDO DEBIAN_FRONTEND="noninteractive" apt install chromium -y $DEBUG_STD
+    eval $SUDO DEBIAN_FRONTEND="noninteractive" apt install python3 python3-pip gcc build-essential ruby git curl libpcap-dev wget zip python3-dev pv dnsutils libssl-dev libffi-dev libxml2-dev libxslt1-dev zlib1g-dev nmap jq apt-transport-https lynx tor medusa -y $DEBUG_STD
     eval $SUDO systemctl enable tor $DEBUG_STD
 }
 


### PR DESCRIPTION
The install.sh script could hang during the install_apt() function when
apt-get expects user interaction, even though the -y argument is provided.
I added DEBIAN_FRONTEND="noninteractive" in front of the calls to
apt install to help prevent this.

Tested on fresh Ubuntu 18.04, Ubuntu 20.04 and Debian 10 docker images.

Resolves #289