### PR TITLE
wait for fleet init

### DIFF
--- a/reconftw.sh
+++ b/reconftw.sh
@@ -1897,6 +1897,14 @@ function axiom_lauch(){
 
 			echo "axiom-fleet ${AXIOM_FLEET_NAME} ${AXIOM_ARGS}"
 			axiom-fleet ${AXIOM_FLEET_NAME} ${AXIOM_ARGS}
+
+			# Keep checking into they are all there
+			while [[ "$NUMOFNODES" -lt  "$AXIOM_FLEET_COUNT" ]]; do
+				echo "Current: $NUMOFNODES | Target: $AXIOM_FLEET_COUNT"
+				sleep 30s
+				NUMOFNODES=$(timeout 30 axiom-ls | grep -c "$AXIOM_FLEET_NAME" )
+			done
+			
 			axiom-select "$AXIOM_FLEET_NAME*"
 			if [ -n "$AXIOM_POST_START" ]; then
 				eval "$AXIOM_POST_START" 2>>"$LOGFILE" &>/dev/null


### PR DESCRIPTION
This adds some validation when spinning up an `axiom-fleet`, making the script wait until all instances are up before proceeding. In my usage, I found this increased reliability of using `axiom-fleet` in concert with the script- avoiding cases where the fleet did not come up fast enough and wasn't ready to begin work. 