### PR TITLE
Docker improvements & optimisations

### DIFF
--- a/Docker/01_nodoc
+++ b/Docker/01_nodoc
@@ -1,0 +1,9 @@
+path-exclude /usr/share/doc/*
+# we need to keep copyright files for legal reasons
+path-include /usr/share/doc/*/copyright
+path-exclude /usr/share/man/*
+path-exclude /usr/share/groff/*
+path-exclude /usr/share/info/*
+# lintian stuff is small, but really unnecessary
+path-exclude /usr/share/lintian/*
+path-exclude /usr/share/linda/*

--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -1,20 +1,20 @@
 # syntax=docker/dockerfile:1.3-labs
 
-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#
+#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#
 
-FROM kalilinux/kali-rolling:latest
+## You can change these variables
+ARG COLLAB_SERVER="XXXXXXXXXX"
+ARG XSS_SERVER="XXXXXXXXXXX"
+ARG SHODAN_API_KEY="XXXXXXXXXXXXXX"
 
-## You can change this
-ENV COLLAB_SERVER='XXXXXXXXXX'
-ENV XSS_SERVER='XXXXXXXXXXX'
-ENV SHODAN_API_KEY='XXXXXXXXXXXXXX'
+ARG LANG=en_US.UTF-8
+ARG LANGUAGE=en_US
 
-## Do NOT change this
-ENV DEBIAN_FRONTEND=noninteractive
-ENV DEBCONF_NONINTERACTIVE_SEEN=true
-ENV GOPATH=$HOME/go
-ENV GOROOT=/usr/local/go
-ENV PATH=$GOPATH/bin:$GOROOT/bin:$PATH
+##################################################
+###> Do NOT change anything beyond this point <###
+##################################################
+
+FROM kalilinux/kali-rolling:latest AS base
 
 LABEL org.label-schema.name='reconftw'
 LABEL org.label-schema.description='A simple script for full recon'
@@ -23,21 +23,46 @@ LABEL org.label-schema.url='https://github.com/six2dez/reconftw'
 LABEL org.label-schema.docker.cmd.devel='docker run --rm -ti six2dez/reconftw'
 LABEL MAINTAINER="six2dez"
 
+ARG COLLAB_SERVER
+ARG XSS_SERVER
+ARG SHODAN_API_KEY
+
+ARG LANG
+ARG LANGUAGE
+
+ENV COLLAB_SERVER=$COLLAB_SERVER
+ENV XSS_SERVER=$XSS_SERVER
+ENV SHODAN_API_KEY=$SHODAN_API_KEY
+
+ENV LANG=$LANG
+ENV LANGUAGE=$LANGUAGE
+ENV LC_ALL=$LANG
+
+ENV DEBIAN_FRONTEND=noninteractive
+ENV DEBCONF_NONINTERACTIVE_SEEN=true
+
+ENV GOPATH=$HOME/go
+ENV GOROOT=/usr/local/go
+ENV PATH=$GOPATH/bin:$GOROOT/bin:$PATH
+
+COPY 01_nodoc /etc/dpkg/dpkg.cfg.d/
+
 RUN <<eot
 #!/bin/bash
 set -x
 ############> Update Sources <############
 echo "deb http://kali.download/kali kali-rolling main contrib non-free" > /etc/apt/sources.list
 echo "deb-src http://kali.download/kali kali-rolling main contrib non-free" >> /etc/apt/sources.list
-############> System Update <############
+############> System Configuration <############
+apt clean all
 apt update
 apt full-upgrade -f -y --allow-downgrades
-apt install -y git wget
-############> Install Golang <############
-GO_BIN=$(wget -qO- https://golang.org/dl/ | grep -oP 'go([0-9\.]+)\.linux-amd64\.tar\.gz' | head -n 1)
-wget https://dl.google.com/go/${GO_BIN}
-tar -xzf ${GO_BIN} -C /usr/local
-ln -sf /usr/local/go/bin/go /usr/bin
+apt install -y --no-install-recommends apt-utils ca-certificates git nano wget
+############> Congifure Locales <############
+apt install -y --no-install-recommends locales
+sed -i -- "/${LANG}/s/^# //g" /etc/locale.gen
+dpkg-reconfigure locales
+update-locale LANG=${LANG}
 ############> Install reconFTW <############
 mkdir -p /root/Tools
 cd /root/Tools
@@ -45,13 +70,19 @@ git clone https://github.com/six2dez/reconftw.git
 cd reconftw
 ./install.sh
 ############> Clean up <############
-rm -f "/${GO_BIN}"
-rm -rf "/root/go" "/root/.cache/go"
+apt update
+apt remove --purge -y build-essential
 apt autoremove -y
+apt install -y --no-install-recommends localepurge
+sed -i -- '/^USE_DPKG/s/^/#/' /etc/locale.nopurge
+dpkg-reconfigure localepurge
+localepurge
 apt clean all
 find /var/cache -type f -delete
 find /var/lib/apt/lists -type f -delete
 find /var/log -type f -delete
+rm -rf /root/.cache
+rm -rf /root/go
 eot
 
 COPY amass_config.ini /root/.config/amass/config.ini
@@ -60,5 +91,5 @@ COPY notify.conf /root/.config/notify/notify.conf
 COPY subfinder_config.yaml /root/.config/subfinder/config.yaml
 
 WORKDIR /root/Tools/reconftw
-ENTRYPOINT ["bash", "reconftw.sh"]
+ENTRYPOINT [ "bash", "reconftw.sh" ]
 CMD [ "--help" ]

--- a/README.md
+++ b/README.md
@@ -122,6 +122,12 @@ docker buildx build -t reconftw Docker/.
 # Running from reconftw root folder, configure values properly for your needs
 docker run -v $PWD/reconftw.cfg:/root/Tools/reconftw/reconftw.cfg -v $PWD/Recon/:/root/Tools/reconftw/Recon/ --name reconftwSCAN --rm reconftw -d target.com -r
 ```
+
+#### You can also choose to configure a locale at build time
+
+```
+docker buildx build --build-arg LANG=es_ES.UTF-8 --build-arg LANGUAGE=es_ES -t reconftw Docker/.
+```
  
 # ⚙️ Config file:
 > A detailed explaintion of config file can be found here [Configuration file](https://github.com/six2dez/reconftw/wiki/3.-Configuration-file) :book:

--- a/install.sh
+++ b/install.sh
@@ -181,14 +181,14 @@ if [[ $(eval type go $DEBUG_ERROR | grep -o 'go is') == "go is" ]] && [ "$versio
                 eval wget https://dl.google.com/go/${version}.linux-arm64.tar.gz $DEBUG_STD
                 eval $SUDO tar -C /usr/local -xzf ${version}.linux-arm64.tar.gz $DEBUG_STD
             fi
-	elif [ "True" = "$IS_MAC" ]; then
-	    eval wget https://dl.google.com/go/${version}.darwin-amd64.tar.gz $DEBUG_STD
+        elif [ "True" = "$IS_MAC" ]; then
+            eval wget https://dl.google.com/go/${version}.darwin-amd64.tar.gz $DEBUG_STD
             eval $SUDO tar -C /usr/local -xzf ${version}.darwin-amd64.tar.gz $DEBU
         else
             eval wget https://dl.google.com/go/${version}.linux-amd64.tar.gz $DEBUG_STD
             eval $SUDO tar -C /usr/local -xzf ${version}.linux-amd64.tar.gz $DEBUG_STD
         fi
-        eval $SUDO cp /usr/local/go/bin/go /usr/local/bin
+        eval $SUDO ln -sf /usr/local/go/bin/go /usr/local/bin/
         rm -rf $version*
         export GOROOT=/usr/local/go
         export GOPATH=$HOME/go


### PR DESCRIPTION
There are 4 major changes in this PR.

1. Removed Golang configuration from Dockerfile.
Rationale: Initially, both Dockerfile & `install.sh` were fetching Golang version dynamically. However, in v2.1.4 `install.sh` was changed & Golang version was statically defined. It might happen that Dockerfile installs Golang only for `install.sh` to remove & re-install a different version. Better to just let `install.sh` configure Golang. 

2. Changed `install.sh` to symlink Golang binary instead of copy it.
Rationale: This is a space saving measure initially implemented in Dockerfile. Since Dockerfile is not configuring Golang anymore I decided to modify `install.sh`

3. Added file `01_nodoc` to `Docker/`
Rationale: This file is a `dpkg` configuration file which tells `apt` to ignore docs & man-pages when installing packages - improving container space saving.

4. Added option to configure locale
Rationale: Since I am using the container as a axiom-fleet controller I find it useful to have the locale configured (which is `C.UTF-8` by default). I honestly don't know if this is going to be useful to other people.

Additionally, line 184 & 185 in `install.sh` were incorrectly indented.

Finally: there are sundry optimisations to the Dockerfile which bring down the container size a further ~23% (from the latest build). You can inspect a CI workflow output [here](https://github.com/frost19k/reconftw-docker/actions/runs/1639793923).

```
❯ docker images
REPOSITORY          TAG       IMAGE ID       CREATED        SIZE
frost19k/reconftw   latest    df6992ff9da7   3 hours ago    3.44GB
six2dez/reconftw    main      67d2537594ff   6 hours ago    4.46GB
```