### PR TITLE
fix gowitness install error

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -71,7 +71,7 @@ gotools["roboxtractor"]="go get -u -v github.com/Josue87/roboxtractor"
 gotools["mapcidr"]="GO111MODULE=on go get -v github.com/projectdiscovery/mapcidr/cmd/mapcidr"
 gotools["clouddetect"]="go get github.com/99designs/clouddetect/cli/clouddetect"
 gotools["dnstake"]="go install github.com/pwnesia/dnstake/cmd/dnstake@latest"
-gotools["gowitness"]="go get -u github.com/sensepost/gowitness"
+gotools["gowitness"]="GO111MODULE=on go get -u github.com/sensepost/gowitness"
 gotools["cero"]="go get -u github.com/glebarez/cero"
 
 declare -A repos


### PR DESCRIPTION
`gowitness` fails to install with `404 module not found` error in the "Running: Installing Golang tools" stage. 

You can confirm this in the CI workflow logs.

![Screenshot from 2022-02-28 16-45-18](https://user-images.githubusercontent.com/49780407/155974128-1ee44b5c-4cb2-43b1-9b76-c9c66c64fd50.png)

However, `gowitness` then successfully installs in the "Running: Double check for installed tools" stage.

I suspect that the `GO111MODULE` variable is getting set to `on` somewhere in between - since setting this variable removes the error in the initial stage.