### PR TITLE
Update reconftw.sh

### DIFF
--- a/reconftw.sh
+++ b/reconftw.sh
@@ -1144,7 +1144,7 @@ function urlchecks(){
 					fi
 				fi
 				[ -s ".tmp/gospider.txt" ] && sed -i '/^.\{2048\}./d' .tmp/gospider.txt
-				[ -s ".tmp/gospider.txt" ] && cat .tmp/gospider.txt | grep -aEo 'https?://[^ ]+' | sed 's/]$//' | grep "$domain" | anew -q .tmp/url_extract_tmp.txt
+				[ -s ".tmp/gospider.txt" ] && cat .tmp/gospider.txt | grep -aEo 'https?://[^ ]+' | sed 's/]$//' | grep -E "^(http|https):[\/]{2}([a-zA-Z0-9\-\.]+\.$domain)" | anew -q .tmp/url_extract_tmp.txt
 			else
 				axiom-scan .tmp/webs_all.txt -m waybackurls -o .tmp/url_extract_way_tmp.txt $AXIOM_EXTRA_ARGS 2>>"$LOGFILE" &>/dev/null
 				[ -s ".tmp/url_extract_way_tmp.txt" ] && cat .tmp/url_extract_way_tmp.txt | anew -q .tmp/url_extract_tmp.txt
@@ -1160,7 +1160,7 @@ function urlchecks(){
 					[[ -d .tmp/gospider/ ]] && find .tmp/gospider -type f -exec cat {} + | sed '/^.\{2048\}./d' | anew -q .tmp/gospider.txt
 				fi
 				[[ -d .tmp/gospider/ ]] && NUMFILES=$(find .tmp/gospider/ -type f | wc -l)
-				[[ $NUMFILES -gt 0 ]] && cat .tmp/gospider.txt | grep -aEo 'https?://[^ ]+' | sed 's/]$//' | grep ".$domain" | anew -q .tmp/url_extract_tmp.txt
+				[[ $NUMFILES -gt 0 ]] && cat .tmp/gospider.txt | grep -aEo 'https?://[^ ]+' | sed 's/]$//' | grep -E "^(http|https):[\/]{2}([a-zA-Z0-9\-\.]+\.$domain)" | anew -q .tmp/url_extract_tmp.txt
 			fi
 			if [ -s "${GITHUB_TOKENS}" ]; then
 				github-endpoints -q -k -d $domain -t ${GITHUB_TOKENS} -o .tmp/github-endpoints.txt 2>>"$LOGFILE" &>/dev/null


### PR DESCRIPTION
sometimes url_extract_tmp.txt file contains external domains like Facebook, twitter, etc. The grep functions searches for the match anywhere in the gospider URLs. This also matches Facebook URLs contain target domain in the parameter value.


Example:
```
cat gospider.txt

http://test.domain.com/pathone
https://a.b.c.domain.com/pathtwo
https://testing123.domain.com/paththree
https://test.com/path1
https://facebook.com/path2?param1=domain.com
https://twitter.com/test?a=domain.com
```

```
cat gospider.txt | grep 'domain.com'

http://test.domain.com/pathone
https://a.b.c.domain.com/pathtwo
https://testing123.domain.com/paththree
https://facebook.com/path2?param1=domain.com
https://twitter.com/test?a=domain.com
```

```
cat gospider.txt | grep -E "^(http|https):[\/]{2}([a-zA-Z0-9\-\.]+\.domain.com)"

http://test.domain.com/pathone
https://a.b.c.domain.com/pathtwo
https://testing123.domain.com/paththree
```
