### PR TITLE
Fix standard repo install

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -36,7 +36,7 @@ BASH_VERSION=$(bash --version | awk 'NR==1{print $4}' | cut -d'.' -f1)
 if [ ${BASH_VERSION} -lt 4 ]; then
      printf "${bred} Your Bash version is lower than 4, please update${reset}\n"
     if [ "True" = "$IS_MAC" ]; then
-        printf "${yellow} For MacOS run 'brew install bash' and rerun installer in a new terminal${reset}\n\n" 
+        printf "${yellow} For MacOS run 'brew install bash' and rerun installer in a new terminal${reset}\n\n"
         exit 1;
     fi
 fi
@@ -294,10 +294,10 @@ for repo in "${!repos[@]}"; do
         eval $SUDO pip3 install . $DEBUG_STD
     fi
     if [ -s "requirements.txt" ]; then
-        #eval $SUDO pip3 install -r requirements.txt $DEBUG_STD
-        eval $SUDO python3 setup.py install --record files.txt $DEBUG_STD
-        [ -s "files.txt" ] && eval xargs rm -rf < files.txt $DEBUG_STD
-        eval $SUDO pip3 install . $DEBUG_STD
+        eval $SUDO pip3 install -r requirements.txt $DEBUG_STD
+        # eval $SUDO python3 setup.py install --record files.txt $DEBUG_STD
+        # [ -s "files.txt" ] && eval xargs rm -rf < files.txt $DEBUG_STD
+        # eval $SUDO pip3 install . $DEBUG_STD
     fi
     if [ "massdns" = "$repo" ]; then
             eval make $DEBUG_STD && strip -s bin/massdns && eval $SUDO cp bin/massdns /usr/local/bin/ $DEBUG_ERROR


### PR DESCRIPTION
The current logic is polluting the Python environment.

```Bash
❯ docker run -it --rm --entrypoint interlace frost19k/reconftw:latest
usage: interlace [-h] (-t TARGET | -tL FILE) [-e EXCLUSIONS | -eL FILE] [-threads THREADS] [-timeout TIMEOUT] [-pL FILE] (-c COMMAND | -cL FILE) [-o OUTPUT] [-p PORT] [--proto PROTO] [-rp REALPORT]
                 [-random RANDOM] [--no-cidr] [--no-color] [--no-bar] [--repeat REPEAT] [-v | --silent]
interlace: error: one of the arguments -t -tL is required

❯ docker run -it --rm --entrypoint interlace six2dez/reconftw:main
Traceback (most recent call last):
  File "/usr/local/bin/interlace", line 5, in <module>
    from Interlace.interlace import main
  File "/usr/local/lib/python3.10/dist-packages/Interlace/interlace.py", line 6, in <module>
    from Interlace.lib.core.output import OutputHelper, Level
  File "/usr/local/lib/python3.10/dist-packages/Interlace/lib/core/output.py", line 4, in <module>
    from colorclass import Color
  File "/usr/local/lib/python3.10/dist-packages/colorclass-2.2.0-py3.10.egg/colorclass/__init__.py", line 11, in <module>
  File "/usr/local/lib/python3.10/dist-packages/colorclass-2.2.0-py3.10.egg/colorclass/codes.py", line 4, in <module>
ImportError: cannot import name 'Mapping' from 'collections' (/usr/lib/python3.10/collections/__init__.py)

```