### PR TITLE
Update onelistforallmicro.txt URL

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -371,7 +371,7 @@ wget -q -O - https://raw.githubusercontent.com/trickest/resolvers/main/resolvers
 wget -q -O - https://raw.githubusercontent.com/trickest/resolvers/main/resolvers.txt > ${resolvers} 
 wget -q -O - https://gist.github.com/six2dez/a307a04a222fab5a57466c51e1569acf/raw > ${subs_wordlist}
 wget -q -O - https://gist.github.com/six2dez/ffc2b14d283e8f8eff6ac83e20a3c4b4/raw > ${tools}/permutations_list.txt
-wget -q -O - https://media.githubusercontent.com/media/six2dez/OneListForAll/main/onelistforallmicro.txt > ${fuzz_wordlist}
+wget -q -O - https://raw.githubusercontent.com/six2dez/OneListForAll/main/onelistforallmicro.txt > ${fuzz_wordlist}
 wget -q -O - https://gist.githubusercontent.com/six2dez/a89a0c7861d49bb61a09822d272d5395/raw > ${lfi_wordlist}
 wget -q -O - https://gist.githubusercontent.com/six2dez/ab5277b11da7369bf4e9db72b49ad3c1/raw > ${ssti_wordlist}
 wget -q -O - https://gist.github.com/six2dez/d62ab8f8ffd28e1c206d401081d977ae/raw > ${tools}/headers_inject.txt


### PR DESCRIPTION
Changed fuzz_wordlist URL 
from: https://media.githubusercontent.com/media/six2dez/OneListForAll/main/onelistforallmicro.txt 
to: https://raw.githubusercontent.com/six2dez/OneListForAll/main/onelistforallmicro.txt