### PR TITLE
feat: support custom output path in notify flow

### DIFF
--- a/reconftw.sh
+++ b/reconftw.sh
@@ -1918,9 +1918,10 @@ function zipSnedOutputFolder {
 	zip_name="$zip_name"_"$domain.zip"
 	(cd $dir && zip -r "../$zip_name" .)
 
-	if [ -s "$SCRIPTPATH/$zip_name" ]; then
-		sendToNotify "$SCRIPTPATH/$zip_name"
-		rm -f "$SCRIPTPATH/$zip_name"
+	echo "Sending zip file "${dir_output}/${zip_name}""
+	if [ -s "$dir_output/$zip_name" ]; then
+		sendToNotify "$dir_output/$zip_name"
+		rm -f "$dir_output/$zip_name"
 	else
 		notification "No Zip file to send" warn
 	fi


### PR DESCRIPTION
This fixes the logic for sending the output zip to subscribers via notify. 

Currently, we assume the output path is the same as `$SCRIPTPATH`, but this is a bad assumption. Anyone following [Data Keep](https://github.com/six2dez/reconftw#data-keep) would run into this issue since it implies the creation of a custom `/Recon` output directory. And I believe `$dir_output=$SCRIPTPATH` in the case of defaults (maybe double check this) so it shouldn't cause any issues for users who are not setting a custom output location.

@six2dez WDYT? 👀 