### PR TITLE
refactor: unused entry for git repository install section

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -112,6 +112,7 @@ repos["trufflehog"]="trufflesecurity/trufflehog"
 repos["smuggler"]="defparam/smuggler"
 repos["Web-Cache-Vulnerability-Scanner"]="Hackmanit/Web-Cache-Vulnerability-Scanner"
 repos["regulator"]="cramppet/regulator"
+repos["byp4xx"]="lobuhi/byp4xx"
 
 printf "\n\n${bgreen}#######################################################################${reset}\n"
 printf "${bgreen} reconFTW installer/updater script ${reset}\n\n"

--- a/install.sh
+++ b/install.sh
@@ -112,7 +112,6 @@ repos["trufflehog"]="trufflesecurity/trufflehog"
 repos["smuggler"]="defparam/smuggler"
 repos["Web-Cache-Vulnerability-Scanner"]="Hackmanit/Web-Cache-Vulnerability-Scanner"
 repos["regulator"]="cramppet/regulator"
-repos["regulator"]="lobuhi/byp4xx"
 
 printf "\n\n${bgreen}#######################################################################${reset}\n"
 printf "${bgreen} reconFTW installer/updater script ${reset}\n\n"


### PR DESCRIPTION
- `byp4xx `is installed through `go install` and not through the git repository.
- There was an entry in the git repo section that was clearly a forgotten work in progress. It was seemingly copied from the regulator key on the line above.
