### PR TITLE
Update Dockerfile to install all reconFTW tool

### DIFF
--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -92,7 +92,7 @@ mkdir -p /root/Tools
 mkdir -p /reconftw
 git clone https://github.com/six2dez/reconftw.git /reconftw
 cd /reconftw
-./install.sh
+echo 1 | ./install.sh
 
 ###>> Restore .bashrc <<###
 mv /root/original.bashrc /root/.bashrc


### PR DESCRIPTION
The tools installation are skipped because for the new interactive install.sh script.
I've used echo to choose '`1`' from prompt and start reconFTW installation
Check six2dez#692