### PR TITLE
docs(readme): improve Docker documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,11 @@ docker run -it --rm \
 six2dez/reconftw:main -d example.com -r
 ```
 
-However, if you wish to:
+- View results (they're NOT in the Docker container)
+
+  - As the folder you cloned earlier (named `reconftw`) is being renamed to `OutputFolder`, you'll have to go to that folder to view results.
+
+If you wish to:
 
 1. Dynamically modify the behaviour & function of the image
 2. Build your own container

--- a/README.md
+++ b/README.md
@@ -107,9 +107,9 @@ docker pull six2dez/reconftw:main
 - Run the container
 
 ```bash
-$ docker run -it --rm \
-  -v "${PWD}/OutputFolder/":'/reconftw/Recon/' \
-  six2dez/reconftw:main -d example.com -r
+docker run -it --rm \
+-v "${PWD}/OutputFolder/":'/reconftw/Recon/' \
+six2dez/reconftw:main -d example.com -r
 ```
 
 However, if you wish to:
@@ -401,6 +401,8 @@ reset='\033[0m'
 
 ## Example Usage
 
+**NOTE: this is applicable when you've installed reconFTW on the host (e.g. VM/VPS/cloud) and not in a Docker container.**
+
 ### To perform a full recon on single target
 
 ```bash
@@ -628,7 +630,7 @@ If you want to contribute to this project, you can do it in multiple ways:
 
 This section shows the current financial sponsors of this project
 
-[<img src="https://pbs.twimg.com/profile_images/1360304248534282240/MomOFi40_400x400.jpg" width="100" height=auto>](https://github.com/0xtavian)
+[<img src="https://pbs.twimg.com/profile_images/1578131929794314272/b79Rezd4_400x400.png" width="100" height=auto>](https://github.com/0xtavian)
 
 ## Thanks :pray:
 


### PR DESCRIPTION
- Improved Docker documentation
- **Removed dollar sign:** this caused users to copy a command that includes a dollar sign (which of course doesn't work and requires manual removal)
- Added note to example usage header
- Fixed incorrect image