### PR TITLE
Tool installation fixes mainly

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -519,6 +519,6 @@ eval strip -s "$HOME"/go/bin/* $DEBUG_STD
 eval $SUDO cp "$HOME"/go/bin/* /usr/local/bin/ $DEBUG_STD
 
 
-printf "${yellow} Remember set your api keys:\n - amass (~/.config/amass/config.ini)\n - subfinder (~/.config/subfinder/provider-config.yaml)\n - GitLab (~/Tools/.gitlab_tokens)\n - SSRF Server (COLLAB_SERVER in reconftw.cfg or env var) \n - Blind XSS Server (XSS_SERVER in reconftw.cfg or env var) \n - notify (~/.config/notify/provider-config.yaml) \n - WHOISXML API (WHOISXML_API in reconftw.cfg or env var)\n\n${reset}"
+printf "${yellow} Remember set your api keys:\n - amass (~/.config/amass/config.ini)\n - subfinder (~/.config/subfinder/provider-config.yaml)\n - GitHub (~/Tools/.github_tokens)\n - GitLab (~/Tools/.gitlab_tokens)\n - SSRF Server (COLLAB_SERVER in reconftw.cfg or env var) \n - Waymore ( ~/.config/waymore/config.yml) \n - Blind XSS Server (XSS_SERVER in reconftw.cfg or env var) \n - notify (~/.config/notify/provider-config.yaml) \n - WHOISXML API (WHOISXML_API in reconftw.cfg or env var)\n\n${reset}"
 printf "${bgreen} Finished!${reset}\n\n"
 printf "\n\n${bgreen}#######################################################################${reset}\n"

--- a/install.sh
+++ b/install.sh
@@ -32,6 +32,7 @@ fi
 # Declaring Go tools and their installation commands
 declare -A gotools
 gotools["gf"]="go install -v github.com/tomnomnom/gf@latest"
+gotools["brutespray"]="go install -v github.com/x90skysn3k/brutespray@latest"
 gotools["qsreplace"]="go install -v github.com/tomnomnom/qsreplace@latest"
 gotools["amass"]="go install -v github.com/owasp-amass/amass/v3/...@master"
 gotools["ffuf"]="go install -v github.com/ffuf/ffuf/v2@latest"
@@ -80,12 +81,9 @@ declare -A repos
 repos["dorks_hunter"]="six2dez/dorks_hunter"
 repos["dnsvalidator"]="vortexau/dnsvalidator"
 repos["interlace"]="codingo/Interlace"
-repos["brutespray"]="x90skysn3k/brutespray"
 repos["wafw00f"]="EnableSecurity/wafw00f"
 repos["gf"]="tomnomnom/gf"
 repos["Gf-Patterns"]="1ndianl33t/Gf-Patterns"
-repos["xnLinkFinder"]="xnl-h4ck3r/xnLinkFinder"
-repos["waymore"]="xnl-h4ck3r/waymore"
 repos["Corsy"]="s0md3v/Corsy"
 repos["CMSeeK"]="Tuhinshubhra/CMSeeK"
 repos["fav-up"]="pielco11/fav-up"

--- a/requirements.txt
+++ b/requirements.txt
@@ -35,5 +35,5 @@ tqdm                    # multiple
 ujson                   # multiple
 urllib3                 # multiple
 porch-pirate            # Tool
-waymore			        # Tool
-xnLinkFinder		    # Tool
+git+https://github.com/xnl-h4ck3r/waymore.git                 # Tool
+git+https://github.com/xnl-h4ck3r/xnLinkFinder.git            # Tool

--- a/requirements.txt
+++ b/requirements.txt
@@ -35,3 +35,5 @@ tqdm                    # multiple
 ujson                   # multiple
 urllib3                 # multiple
 porch-pirate            # Tool
+waymore			        # Tool
+xnLinkFinder		    # Tool


### PR DESCRIPTION
So I've updated **brutespray** , **waymore,** **xnLinkFinder** install with their new installation methods.
I have updated the instalaltion checks for the above.
I have updated the calling of the tools since they can now be called globally via path binary instead of using python.
I have updated the Post install message to include Github tokens and waymore config path.
