### PR TITLE
Adding Metafinder & Whois to installed tools check.

### DIFF
--- a/reconftw.sh
+++ b/reconftw.sh
@@ -225,6 +225,14 @@ function tools_installed() {
 		printf "${bred} [*] dnsvalidator		[NO]${reset}\n"
 		allinstalled=false
 	}
+	command -v metafinder &>/dev/null || {
+		printf "${bred} [*] metafinder			[NO]${reset}\n"
+		allinstalled=false
+	}
+	command -v whois &>/dev/null || {
+		printf "${bred} [*] whois			[NO]${reset}\n"
+		allinstalled=false
+	}
 	command -v amass &>/dev/null || {
 		printf "${bred} [*] Amass			[NO]${reset}\n"
 		allinstalled=false


### PR DESCRIPTION
Please feel free to just copy and paste the addition rather than accept the PR if you prefer.
I find these two tools are often not installed, and the 'installed tools check' doesn't highlight that, so I only discovered they were missing after kicking off an actual scan. Only a minor change, but a QoL improvement for me at least.

I appreciate your work on this tool, 
Thanks.