### PR TITLE
Add soft notfication to multi recon mode

### DIFF
--- a/reconftw.sh
+++ b/reconftw.sh
@@ -3510,7 +3510,7 @@ function multi_recon() {
 	dir=$workdir
 	domain=$multi
 	end
-	[ "$SOFT_NOTIFICATION" = true ] && echo "$(date +'%Y-%m-%d %H:%M:%S') Finished Recon on: ${domain} in ${runtime}" | notify -silent
+	[ "$SOFT_NOTIFICATION" = true ] && echo "$(date +'%Y-%m-%d %H:%M:%S') Finished Recon on: ${multi} in ${runtime}" | notify -silent
 }
 
 function multi_custom() {

--- a/reconftw.sh
+++ b/reconftw.sh
@@ -3308,6 +3308,8 @@ function recon() {
 
 function multi_recon() {
 
+	[ "$SOFT_NOTIFICATION" = true ] && echo "$(date +'%Y-%m-%d %H:%M:%S') Recon successfully started on ${multi}" | notify -silent
+
 	global_start=$(date +%s)
 
 	#[[ -n "$domain" ]] && ipcidr_target $domain
@@ -3508,6 +3510,7 @@ function multi_recon() {
 	dir=$workdir
 	domain=$multi
 	end
+	[ "$SOFT_NOTIFICATION" = true ] && echo "$(date +'%Y-%m-%d %H:%M:%S') Finished Recon on: ${domain} in ${runtime}" | notify -silent
 }
 
 function multi_custom() {


### PR DESCRIPTION
Added notification for start and end of multi recon using organization name. Previously a user running a command like `./reconftw -m hackerone -l hackerone.txt -r` and using soft notifications only (start and end only) would not get any notifcations