### PR TITLE
Add --check-tools option and GitHub workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,39 @@
+name: tests
+
+on: [push, pull_request]
+
+jobs:
+  tests:
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - macos-14
+          - macos-15
+          - ubuntu-20.04
+          - ubuntu-22.04
+          - ubuntu-24.04
+
+    name: ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - name: Install bash from homebrew
+        if: ${{ startsWith(matrix.os, 'macos-') }}
+        run: brew install bash
+
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install reconFTW
+        shell: bash
+        continue-on-error: true
+        run: ./install.sh
+
+      - name: Check if all tools are installed
+        shell: bash
+        run: ./reconftw.sh --check-tools
+
+      - name: Check if chromium dependencies are installed
+        shell: bash
+        run: nuclei -headless -id screenshot

--- a/README.md
+++ b/README.md
@@ -408,6 +408,7 @@ reset='\033[0m'
 | -o | Output directory |
 | -v | Axiom distributed VPS |
 | -q | Rate limit in requests per second |
+| --check-tools | Exit if one of the tools is missing |
 
 ## Example Usage
 


### PR DESCRIPTION
Related to #907. This PR:
- Add option `--check-tools` that will make `./reconftw.sh` exit (with a value greater than 0) if one or more tools are missing. Required for the GitHub workflow.
  - This change also unify the path that is taken when using the `-h, --help` options or when no operation mode are provided (meaning that any execution will always reach the final `case $opt_mode`).
- Add a GitHub workflow to test the `./install.sh` script and make sure that all the tools installs properly ([on the available runners](https://docs.github.com/en/actions/using-github-hosted-runners/using-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources)).