### PR TITLE
Fix macos support

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -19,24 +19,6 @@ double_check=false
 
 # ARM Detection
 ARCH=$(uname -m)
-case "$ARCH" in
-amd64 | x86_64)
-	IS_ARM="False"
-	;;
-arm64 | armv6l | aarch64)
-	IS_ARM="True"
-	if [[ $ARCH == "arm64" ]]; then
-		RPI_4="True"
-		RPI_3="False"
-	else
-		RPI_4="False"
-		RPI_3="True"
-	fi
-	;;
-*)
-	IS_ARM="False"
-	;;
-esac
 
 # macOS Detection
 IS_MAC=$([[ $OSTYPE == "darwin"* ]] && echo "True" || echo "False")
@@ -344,27 +326,30 @@ function install_golang_version() {
 
 			case "$ARCH" in
 			arm64 | aarch64)
-				if [[ $RPI_4 == "True" ]]; then
+				if [[ $IS_MAC == "True" ]]; then
+					wget "https://dl.google.com/go/${version}.darwin-arm64.tar.gz" -O "/tmp/${version}.darwin-arm64.tar.gz" &>/dev/null
+					"$SUDO" tar -C /usr/local -xzf "/tmp/${version}.darwin-arm64.tar.gz" &>/dev/null
+				else
 					wget "https://dl.google.com/go/${version}.linux-arm64.tar.gz" -O "/tmp/${version}.linux-arm64.tar.gz" &>/dev/null
 					"$SUDO" tar -C /usr/local -xzf "/tmp/${version}.linux-arm64.tar.gz" &>/dev/null
-				elif [[ $RPI_3 == "True" ]]; then
-					wget "https://dl.google.com/go/${version}.linux-armv6l.tar.gz" -O "/tmp/${version}.linux-armv6l.tar.gz" &>/dev/null
-					"$SUDO" tar -C /usr/local -xzf "/tmp/${version}.linux-armv6l.tar.gz" &>/dev/null
 				fi
 				;;
-			*)
+			armv6l | armv7l)
+				wget "https://dl.google.com/go/${version}.linux-armv6l.tar.gz" -O "/tmp/${version}.linux-armv6l.tar.gz" &>/dev/null
+				"$SUDO" tar -C /usr/local -xzf "/tmp/${version}.linux-armv6l.tar.gz" &>/dev/null
+				;;
+			amd64 | x86_64)
 				if [[ $IS_MAC == "True" ]]; then
-					if [[ $IS_ARM == "True" ]]; then
-						wget "https://dl.google.com/go/${version}.darwin-arm64.tar.gz" -O "/tmp/${version}.darwin-arm64.tar.gz" &>/dev/null
-						"$SUDO" tar -C /usr/local -xzf "/tmp/${version}.darwin-arm64.tar.gz" &>/dev/null
-					else
-						wget "https://dl.google.com/go/${version}.darwin-amd64.tar.gz" -O "/tmp/${version}.darwin-amd64.tar.gz" &>/dev/null
-						"$SUDO" tar -C /usr/local -xzf "/tmp/${version}.darwin-amd64.tar.gz" &>/dev/null
-					fi
+					wget "https://dl.google.com/go/${version}.darwin-amd64.tar.gz" -O "/tmp/${version}.darwin-amd64.tar.gz" &>/dev/null
+					"$SUDO" tar -C /usr/local -xzf "/tmp/${version}.darwin-amd64.tar.gz" &>/dev/null
 				else
 					wget "https://dl.google.com/go/${version}.linux-amd64.tar.gz" -O "/tmp/${version}.linux-amd64.tar.gz" &>/dev/null
 					"$SUDO" tar -C /usr/local -xzf "/tmp/${version}.linux-amd64.tar.gz" &>/dev/null
 				fi
+				;;
+			*)
+				echo -e "${bred}[!] Unsupported architecture. Please install go manually.${reset}"
+				exit 1
 				;;
 			esac
 

--- a/install.sh
+++ b/install.sh
@@ -425,8 +425,7 @@ function install_brew() {
 		/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
 	fi
 	brew update &>/dev/null
-	brew install --cask chromium &>/dev/null
-	brew install bash coreutils python massdns jq gcc cmake ruby git curl libpcap-dev wget zip python3-dev pipx pv dnsutils whois libssl-dev libffi-dev libxml2-dev libxslt-dev zlib libnss3 atk bridge2.0 cups xkbcommon xcomposite xdamage xrandr gbm pangocairo alsa libxml2-utils &>/dev/null
+	brew install --formula bash coreutils gnu-getopt python pipx massdns jq gcc cmake ruby git curl wget zip pv bind whois nmap jq lynx medusa &>/dev/null
 	brew install rustup &>/dev/null
 	rustup-init -y &>/dev/null
 	cargo install ripgen &>/dev/null

--- a/reconftw.sh
+++ b/reconftw.sh
@@ -6037,8 +6037,21 @@ function help() {
 
 # macOS PATH initialization, thanks @0xtavian <3
 if [[ $OSTYPE == "darwin"* ]]; then
-	PATH="/usr/local/opt/gnu-getopt/bin:$PATH"
-	PATH="/usr/local/opt/coreutils/libexec/gnubin:$PATH"
+	if ! command -v brew &> /dev/null; then
+		printf "\n%bBrew is not installed or not in the PATH.%b\n\n" "$bred" "$reset"
+		exit 1
+	fi
+	if [[ ! -x "$(brew --prefix gnu-getopt)/bin/getopt" ]]; then
+		printf "\n%bBrew formula gnu-getopt is not installed.%b\n\n" "$bred" "$reset"
+		exit 1
+	fi
+	if [[ ! -d "$(brew --prefix coreutils)/libexec/gnubin" ]]; then
+		printf "\n%bBrew formula coreutils is not installed.%b\n\n" "$bred" "$reset"
+		exit 1
+	fi
+	# Prefix is different depending on Intel vs Apple Silicon
+	PATH="$(brew --prefix gnu-getopt)/bin:$PATH"
+	PATH="$(brew --prefix coreutils)/libexec/gnubin:$PATH"
 fi
 
 PROGARGS=$(getopt -o 'd:m:l:x:i:o:f:q:c:z:rspanwvh::' --long 'domain:,list:,recon,subdomains,passive,all,web,osint,zen,deep,help,vps' -n 'reconFTW' -- "$@")


### PR DESCRIPTION
Related to #907. This PR:
- Fix Golang download logic. After adding #920, I notice that the download logic did not yield the expected result on macOS (it was downloading the Linux ARM version). I removed the switch case statement for the arch detection, and move the logic directly in the switch case statement for the download. The resulting switch case should be compatible with Linux and macOS ARM-based system.
- Fix macOS (homebrew) dependencies. Many of the formulae listed were unused or did not exist at all.
  - Add the `--formula` flag to remove warnings.
  - Remove the `chromium` cask as chromium is provided (downloaded) by nuclei.
- Fix macOS path initialization. Since the introduction of Apple Silicon, homebrew installation location varies.
  - Made the script use the `brew --prefix` command to determine the correct PATH.
  - Detect if the gnu-getopt or coreutils formulae are not installed (which happens if the `brew install` command fails).