### PR TITLE
Fix Debian/Ubuntu support and others install fixes

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -425,8 +425,11 @@ function install_system_packages() {
 
 # Function to install required packages for Debian-based systems
 function install_apt() {
-	"$SUDO" apt update -y &>/dev/null
-	"$SUDO" DEBIAN_FRONTEND="noninteractive" apt install -y chromium-browser python3 python3-pip pipx python3-virtualenv build-essential gcc cmake ruby whois git curl libpcap-dev wget zip python3-dev pv dnsutils libssl-dev libffi-dev libxml2-dev libxslt1-dev zlib1g-dev nmap jq apt-transport-https lynx medusa xvfb libxml2-utils procps bsdmainutils libdata-hexdump-perl libnss3 libatk1.0-0 libatk-bridge2.0-0 libcups2 libxkbcommon-x11-0 libxcomposite-dev libxdamage1 libxrandr2 libgbm-dev libpangocairo-1.0-0 libasound2 &>/dev/null
+	"$SUDO" apt-get update -y &>/dev/null
+	"$SUDO" DEBIAN_FRONTEND="noninteractive" apt-get install -y python3 python3-pip python3-venv pipx python3-virtualenv build-essential gcc cmake ruby whois git curl libpcap-dev wget zip python3-dev pv dnsutils libssl-dev libffi-dev libxml2-dev libxslt1-dev zlib1g-dev nmap jq apt-transport-https lynx medusa xvfb libxml2-utils procps bsdmainutils libdata-hexdump-perl &>/dev/null
+	# Move chromium browser dependencies (required by `nuclei -headless -id screenshot`) into a separate apt install command, and add a fallback for Ubuntu 24.04 (where `libasound2` is renamed to `libasound2t64`)
+	"$SUDO" DEBIAN_FRONTEND="noninteractive" apt-get install -y libnss3 libatk1.0-0 libatk-bridge2.0-0 libcups2 libxkbcommon-x11-0 libxcomposite-dev libxdamage1 libxrandr2 libgbm-dev libpangocairo-1.0-0 libasound2 &>/dev/null || \
+		"$SUDO" DEBIAN_FRONTEND="noninteractive" apt-get install -y libnss3 libatk1.0-0 libatk-bridge2.0-0 libcups2 libxkbcommon-x11-0 libxcomposite-dev libxdamage1 libxrandr2 libgbm-dev libpangocairo-1.0-0 libasound2t64 &>/dev/null
 	curl https://sh.rustup.rs -sSf | sh -s -- -y >/dev/null 2>&1
 	source "${HOME}/.cargo/env"
 	cargo install ripgen &>/dev/null

--- a/reconftw.cfg
+++ b/reconftw.cfg
@@ -23,6 +23,9 @@ export GOROOT=/usr/local/go
 export GOPATH=$HOME/go
 export PATH=$GOPATH/bin:$GOROOT/bin:$HOME/.local/bin:$PATH
 
+# Rust Vars (Comment or change on your own)
+export PATH="$HOME/.cargo/bin:$PATH"
+
 # Tools config files
 #NOTIFY_CONFIG=~/.config/notify/provider-config.yaml # No need to define
 GITHUB_TOKENS=${tools}/.github_tokens

--- a/reconftw.sh
+++ b/reconftw.sh
@@ -154,6 +154,13 @@ function tools_installed() {
 	)
 
 	declare -A tools_commands=(
+		["python3"]="python3"
+		["curl"]="curl"
+		["wget"]="wget"
+		["zip"]="zip"
+		["nmap"]="nmap"
+		["dig"]="dig"
+		["timeout"]="timeout"
 		["brutespray"]="brutespray"
 		["xnLinkFinder"]="xnLinkFinder"
 		["urlfinder"]="urlfinder"
@@ -212,6 +219,7 @@ function tools_installed() {
 		["sns"]="sns"
 		["sourcemapper"]="sourcemapper"
 		["jsluice"]="jsluice"
+		["dnstake"]="dnstake"
 	)
 
 	# Check for tool files


### PR DESCRIPTION
Related to #907. This PR:
- Fix Debian/Ubuntu (apt) dependencies.
  - Remove the `chromium-browser` package as chromium is provided (downloaded) by nuclei.
  - Split the dependencies for `chromium` to be compatible with various Ubuntu versions. This address the compatibility issue with Ubuntu 24.04 mentioned in #907.
  - Use `apt-get` as `apt` should not be use for scripting.
- Add `~/.cargo/bin` in path (Rust) in `reconftw.cfg`. After adding #920, I noticed that one of the tools was missing. This was due to the `.bashrc` file not being reloaded after running `./install.sh`. Since the Golang environment variables are added in this file, I did the same for Cargo/Rust.
- Add missing tools in tools check. Some tools check were missing from `./reconftw.sh`. This help to detect if`./install.sh` failed to install the system packages (which happens if one of the packages does not exists or if there is a choice to make).