### PR TITLE
Miscellaneous fixes

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -269,7 +269,7 @@ function install_tools() {
 		if [[ $repo == "gf" ]]; then
 			cp -r examples ${HOME}/.gf &>/dev/null
 		elif [[ $repo == "Gf-Patterns" ]]; then
-			mv ./*.json ${HOME}/.gf &>/dev/null
+			cp ./*.json ${HOME}/.gf &>/dev/null
 		fi
 
 		# Return to the main directory

--- a/install.sh
+++ b/install.sh
@@ -114,7 +114,7 @@ declare -A repos=(
 	["fav-up"]="pielco11/fav-up"
 	["massdns"]="blechschmidt/massdns"
 	["Oralyzer"]="r0075h3ll/Oralyzer"
-	["testssl"]="drwetter/testssl.sh"
+	["testssl.sh"]="drwetter/testssl.sh"
 	["commix"]="commixproject/commix"
 	["JSA"]="w9w/JSA"
 	["CloudHunter"]="belane/CloudHunter"
@@ -518,15 +518,6 @@ function initial_setup() {
 	else
 		#printf "${yellow}Updating sqlmap...${reset}\n"
 		eval git -C "${dir}/sqlmap" pull $DEBUG_STD
-	fi
-
-	# testssl.sh
-	if [[ ! -d "${dir}/testssl.sh" ]]; then
-		#printf "${yellow}Cloning testssl.sh...${reset}\n"
-		eval git clone --depth 1 https://github.com/drwetter/testssl.sh.git "${dir}/testssl.sh" $DEBUG_STD
-	else
-		#printf "${yellow}Updating testssl.sh...${reset}\n"
-		eval git -C "${dir}/testssl.sh" pull $DEBUG_STD
 	fi
 
 	# massdns

--- a/install.sh
+++ b/install.sh
@@ -260,6 +260,9 @@ function install_tools() {
 			go build -o misconfig-mapper &>/dev/null
 			chmod +x ./misconfig-mapper
 			;;
+		"trufflehog")
+			go install &>/dev/null
+			;;
 		esac
 
 		# Copy gf patterns if applicable

--- a/install.sh
+++ b/install.sh
@@ -249,7 +249,7 @@ function install_tools() {
 			chmod +x ./nomore403
 			;;
 		"ffufPostprocessing")
-			git reset --hard origin/main &>/dev/null
+			git reset --hard origin/master &>/dev/null
 			git pull &>/dev/null
 			go build -o ffufPostprocessing main.go &>/dev/null
 			chmod +x ./ffufPostprocessing

--- a/reconftw.sh
+++ b/reconftw.sh
@@ -122,7 +122,7 @@ function tools_installed() {
 		["dorks_hunter"]="${tools}/dorks_hunter/dorks_hunter.py"
 		["fav-up"]="${tools}/fav-up/favUp.py"
 		["Corsy"]="${tools}/Corsy/corsy.py"
-		["testssl"]="${tools}/testssl.sh/testssl.sh"
+		["testssl.sh"]="${tools}/testssl.sh/testssl.sh"
 		["CMSeeK"]="${tools}/CMSeeK/cmseek.py"
 		["OneListForAll"]="$fuzz_wordlist"
 		["lfi_wordlist"]="$lfi_wordlist"


### PR DESCRIPTION
Related to #907. This PR:
- Remove duplicate testssl repository. The `testssl.sh` tool was install twice, once as `testssl` and a second time as `testssl.sh`. This fix rename the first one, and remove the second one, remaining compatible with the paths in `./reconftw.sh`.
- Fix ffufPostprocessing branch name. ffufPostprocessing uses `master`, not `main`.
- Restore special handling for trufflehog. This feature was present in the past but was removed by c46277a486b12fd0dbeeab16844d11ae996f2228.
- Copy gf patterns instead of moving. This is consistent with the special configurations section bellow. 