### PR TITLE
Fix Nuclei Severity Filters

### DIFF
--- a/reconftw.sh
+++ b/reconftw.sh
@@ -3287,7 +3287,7 @@ function nuclei_check() {
 			for crit in "${severity_array[@]}"; do
 				printf "${yellow}\n[$(date +'%Y-%m-%d %H:%M:%S')] Running: Nuclei Severity: $crit ${reset}\n\n"
 				# Run nuclei for each severity level
-				nuclei "$NUCLEI_FLAGS" -severity "$crit" -nh -rl "$NUCLEI_RATELIMIT" "$NUCLEI_EXTRA_ARGS" -j -o "nuclei_output/${crit}_json.txt" <.tmp/webs_nuclei.txt
+				nuclei -severity "$crit" -nh -rl "$NUCLEI_RATELIMIT" "$NUCLEI_FLAGS" "$NUCLEI_EXTRA_ARGS" -j -o "nuclei_output/${crit}_json.txt" <.tmp/webs_nuclei.txt
 
 				# Parse the JSON output and save the results to a text file
 				if [[ -s "nuclei_output/${crit}_json.txt" ]]; then


### PR DESCRIPTION
The $NUCLEI_FLAGS which includes `-silent -t /home/kleoz/nuclei-templates/ -retries 2` by default in the config , if put before the -severity flag it overwrites t , it needs to be after the severity flag like this:

`nuclei -severity "$crit" -nh -rl "$NUCLEI_RATELIMIT" "$NUCLEI_FLAGS" "$NUCLEI_EXTRA_ARGS" -j -o "nuclei_output/${crit}_json.txt" <.tmp/webs_nuclei.txt `