### PR TITLE
fix(install): update misconfig-mapper install step due to upstream changes

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -83,6 +83,7 @@ declare -A gotools=(
 	["jsluice"]="go install -v github.com/BishopFox/jsluice/cmd/jsluice@latest"
 	["urlfinder"]="go install -v github.com/projectdiscovery/urlfinder/cmd/urlfinder@latest"
 	["cent"]="go install -v github.com/xm1k3/cent@latest"
+	["misconfig-mapper"]="go install -v github.com/intigriti/misconfig-mapper/cmd/misconfig-mapper@latest"
 )
 
 # Declare pipx tools and their paths
@@ -123,7 +124,6 @@ declare -A repos=(
 	["SwaggerSpy"]="UndeadSec/SwaggerSpy"
 	["LeakSearch"]="JoelGMSec/LeakSearch"
 	["ffufPostprocessing"]="Damian89/ffufPostprocessing"
-	["misconfig-mapper"]="intigriti/misconfig-mapper"
 	["Spoofy"]="MattKeeley/Spoofy"
 	["msftrecon"]="Arcanum-Sec/msftrecon"
 	["metagoofil"]="opsdisk/metagoofil"
@@ -177,7 +177,7 @@ function install_tools() {
 		fi
 	done
 
-	echo -e "\n${bblue}Running: Installing pipx tools (${#repos[@]})${reset}\n"
+	echo -e "\n${bblue}Running: Installing pipx tools (${#pipxtools[@]})${reset}\n"
 
 	local pipx_step=0
 	local failed_pipx_tools=()
@@ -285,14 +285,6 @@ function install_tools() {
 			git pull &>/dev/null
 			go build -o ffufPostprocessing main.go &>/dev/null
 			chmod +x ./ffufPostprocessing
-			;;
-		"misconfig-mapper")
-			git reset --hard origin/main &>/dev/null
-			git pull &>/dev/null
-			go mod tidy &>/dev/null
-			go build -o misconfig-mapper &>/dev/null
-			chmod +x ./misconfig-mapper &>/dev/null
-			cp misconfig-mapper $HOME/go/bin/ &>/dev/null
 			;;
 		"trufflehog")
 			go install &>/dev/null

--- a/reconftw.sh
+++ b/reconftw.sh
@@ -152,7 +152,6 @@ function tools_installed() {
 		["regulator_python"]="${tools}/regulator/venv/bin/python3"
 		["nomore403"]="${tools}/nomore403/nomore403"
 		["ffufPostprocessing"]="${tools}/ffufPostprocessing/ffufPostprocessing"
-		["misconfig-mapper"]="${tools}/misconfig-mapper/misconfig-mapper"
 		["spoofy"]="${tools}/Spoofy/spoofy.py"
 		["spoofy_python"]="${tools}/Spoofy/venv/bin/python3"
 		["swaggerspy"]="${tools}/SwaggerSpy/swaggerspy.py"
@@ -590,22 +589,8 @@ function third_party_misconfigs() {
 		# Extract company name from domain
 		company_name=$(unfurl format %r <<<"$domain")
 
-		# Change directory to misconfig-mapper tool
-		if ! pushd "${tools}/misconfig-mapper" >/dev/null; then
-			printf "%b[!] Failed to change directory to %s in %s at line %s.%b\n" \
-				"$bred" "${tools}/misconfig-mapper" "${FUNCNAME[0]}" "$LINENO" "$reset"
-			return 1
-		fi
-
 		# Run misconfig-mapper and handle errors
-		./misconfig-mapper -target "$company_name" -service "*" 2>&1 | grep -v "\-\]" | grep -v "Failed" >"${dir}/osint/3rdparts_misconfigurations.txt"
-
-		# Return to the previous directory
-		if ! popd >/dev/null; then
-			printf "%b[!] Failed to return to previous directory in %s at line %s.%b\n" \
-				"$bred" "${FUNCNAME[0]}" "$LINENO" "$reset"
-			return 1
-		fi
+		misconfig-mapper -target "$company_name" -service "*" 2>&1 | grep -v "\-\]" | grep -v "Failed" >"${dir}/osint/3rdparts_misconfigurations.txt"
 
 		end_func "Results are saved in $domain/osint/3rdparts_misconfigurations.txt" "${FUNCNAME[0]}"
 


### PR DESCRIPTION
## Summary

This PR updates the installation step for **misconfig-mapper** to reflect recent changes in their upstream repository. The previous method no longer works due to modifications in their install script or repo structure.

## Changes

- Updated the install logic/command for misconfig-mapper
- Ensured compatibility with the latest version from the upstream repository

## Motivation

The upstream project changed their installation process, which broke our current setup. This fix ensures a smooth installation using the updated method.

## Checklist

- [x] Verified new install step works as expected  
- [x] Tested on a clean environment
