### PR TITLE
fix fuzzparams

### DIFF
--- a/reconftw.sh
+++ b/reconftw.sh
@@ -5018,7 +5018,7 @@ function fuzzparams() {
 				fi
 
 				# Execute Nuclei with the fuzzing templates
-				nuclei -l webs/url_extract_nodupes.txt -nh -rl "$NUCLEI_RATELIMIT" -silent -retries 2 ${NUCLEI_EXTRA_ARGS} -t ${NUCLEI_FUZZING_TEMPLATES_PATH} -dast -j -o ".tmp/fuzzparams_json.txt" <"webs/url_extract_nodupes.txt" 2>>"$LOGFILE" >/dev/null
+				nuclei -l webs/webs_nuclei.txt -nh -rl "$NUCLEI_RATELIMIT" -silent -retries 2 ${NUCLEI_EXTRA_ARGS} -t ${NUCLEI_TEMPLATES_PATH}/dast -dast -j -o ".tmp/fuzzparams_json.txt" <"webs/url_extract_nodupes.txt" 2>>"$LOGFILE" >/dev/null
 
 			else
 				printf "${yellow}\n[$(date +'%Y-%m-%d %H:%M:%S')] Running: Axiom with Nuclei${reset}\n\n"


### PR DESCRIPTION
Quick and dirty fix for fuzzparams template folder, nuclei no longer uses the archived repo , it instead uses nuclei-templates/dast for fuzzing.

I haven't touched the repo cloning, variables or axiom to not mess it up since I don't use it. This is a quick fix that uses the appropriate template path for fuzzparams on non-axiom scans.