### PR TITLE
Fix macOS Bash path handling and stabilize smoke tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -61,6 +61,32 @@ jobs:
       - name: Run integration smoke tests
         run: ./tests/run_tests.sh --smoke
 
+  macos-smoke:
+    name: macos-smoke
+    runs-on: macos-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: |
+          brew update
+          brew install bash bats-core jq coreutils gnu-getopt gnu-sed
+
+      - name: Configure GNU toolchain PATH
+        run: |
+          BREW_PREFIX="$(brew --prefix)"
+          echo "$BREW_PREFIX/bin" >> "$GITHUB_PATH"
+          echo "$BREW_PREFIX/opt/coreutils/libexec/gnubin" >> "$GITHUB_PATH"
+          echo "$BREW_PREFIX/opt/gnu-getopt/bin" >> "$GITHUB_PATH"
+          echo "$BREW_PREFIX/opt/gnu-sed/libexec/gnubin" >> "$GITHUB_PATH"
+
+      - name: Run unit tests
+        run: ./tests/run_tests.sh --unit
+
+      - name: Run integration smoke tests
+        run: ./tests/run_tests.sh --smoke
+
   integration-full:
     name: integration-full
     runs-on: ubuntu-latest

--- a/install.sh
+++ b/install.sh
@@ -7,9 +7,23 @@ set -E
 set +e
 IFS=$'\n\t'
 
-# Detect if the script is being run in MacOS with Homebrew Bash
-if [[ $OSTYPE == "darwin"* && $BASH != "/opt/homebrew/bin/bash" ]]; then
-    exec /opt/homebrew/bin/bash "$0" "$@"
+# Detect if the script is being run in macOS and re-exec with modern Bash.
+# Supports both Apple Silicon (/opt/homebrew) and Intel (/usr/local) Homebrew prefixes.
+if [[ $OSTYPE == "darwin"* ]]; then
+    _mac_bash=""
+    for _candidate in /opt/homebrew/bin/bash /usr/local/bin/bash /bin/bash; do
+        if [[ -x "$_candidate" ]]; then
+            _major="$("$_candidate" -lc 'echo "${BASH_VERSINFO[0]}"' 2>/dev/null || echo 0)"
+            if [[ "$_major" =~ ^[0-9]+$ ]] && [[ "$_major" -ge 4 ]]; then
+                _mac_bash="$_candidate"
+                break
+            fi
+        fi
+    done
+    if [[ -n "$_mac_bash" ]] && [[ "$BASH" != "$_mac_bash" ]]; then
+        exec "$_mac_bash" "$0" "$@"
+    fi
+    unset _mac_bash _candidate _major
 fi
 
 # Load main configuration

--- a/modules/core.sh
+++ b/modules/core.sh
@@ -174,9 +174,16 @@ function check_version() {
         return 1
     fi
 
-    # Fetch updates with a timeout (supports gtimeout on macOS)
-    if ! { [[ -n $TIMEOUT_CMD ]] && $TIMEOUT_CMD 10 git fetch >/dev/null 2>&1; } && ! git fetch >/dev/null 2>&1; then
-        _print_error "Unable to check updates (git fetch timed out)"
+    # Fetch updates with a bounded timeout when available.
+    # Do not run an unbounded fallback fetch after a timeout, otherwise callers
+    # wrapped by `timeout` (tests/CI) can be killed before main logic runs.
+    if [[ -n $TIMEOUT_CMD ]]; then
+        if ! $TIMEOUT_CMD 10 git fetch >/dev/null 2>&1; then
+            _print_error "Unable to check updates (git fetch timed out)"
+            return 1
+        fi
+    elif ! git fetch >/dev/null 2>&1; then
+        _print_error "Unable to check updates"
         return 1
     fi
 

--- a/reconftw.sh
+++ b/reconftw.sh
@@ -648,7 +648,9 @@ if [[ "${SHOW_LEGAL:-false}" == "true" ]]; then
     printf "\n"
 fi
 
-check_version
+if [[ "${DRY_RUN:-false}" != "true" ]]; then
+    check_version
+fi
 
 # Check critical dependencies before proceeding
 if [[ "${SKIP_CRITICAL_CHECK:-false}" != "true" ]]; then

--- a/reconftw.sh
+++ b/reconftw.sh
@@ -35,9 +35,23 @@ fi
 #	   ░        ░  ░░ ░          ░ ░           ░                      ░
 #
 
-# Detect if the script is being run (not sourced) in MacOS with Homebrew Bash
-if [[ "${BASH_SOURCE[0]}" == "${0}" && $OSTYPE == "darwin"* && $BASH != "/opt/homebrew/bin/bash" ]]; then
-    exec /opt/homebrew/bin/bash "$0" "$@"
+# Detect if the script is being run (not sourced) in macOS and re-exec with modern Bash.
+# Supports both Apple Silicon (/opt/homebrew) and Intel (/usr/local) Homebrew prefixes.
+if [[ "${BASH_SOURCE[0]}" == "${0}" && $OSTYPE == "darwin"* ]]; then
+    _mac_bash=""
+    for _candidate in /opt/homebrew/bin/bash /usr/local/bin/bash /bin/bash; do
+        if [[ -x "$_candidate" ]]; then
+            _major="$("$_candidate" -lc 'echo "${BASH_VERSINFO[0]}"' 2>/dev/null || echo 0)"
+            if [[ "$_major" =~ ^[0-9]+$ ]] && [[ "$_major" -ge 4 ]]; then
+                _mac_bash="$_candidate"
+                break
+            fi
+        fi
+    done
+    if [[ -n "$_mac_bash" ]] && [[ "$BASH" != "$_mac_bash" ]]; then
+        exec "$_mac_bash" "$0" "$@"
+    fi
+    unset _mac_bash _candidate _major
 fi
 
 # timeout/gtimeout compatibility


### PR DESCRIPTION
## Summary
  This PR improves macOS compatibility, adds macOS CI coverage, and fixes timeout-related flakes in integration tests.

  ### Changes
  - Added a new `macos-smoke` lane in `.github/workflows/tests.yml` to run:
    - unit tests (`./tests/run_tests.sh --unit`)
    - smoke integration tests (`./tests/run_tests.sh --smoke`)
  - Installed required macOS dependencies in CI:
    - `bash`, `bats-core`, `jq`, `coreutils`, `gnu-getopt`, `gnu-sed`
  - Exported GNU tool paths in CI (`GITHUB_PATH`) for consistent command behavior.
  - Fixed macOS Bash re-exec logic in:
    - `reconftw.sh`
    - `install.sh`
    by replacing hardcoded `/opt/homebrew/bin/bash` with version-aware fallback:
    `/opt/homebrew/bin/bash` -> `/usr/local/bin/bash` -> `/bin/bash` (Bash >= 4).
  - Fixed version-check fetch behavior in `modules/core.sh`:
    - removed unbounded `git fetch` fallback after timeout
    - use timed fetch when `timeout`/`gtimeout` is available
  - Skipped version check in `--dry-run` mode in `reconftw.sh`:
    - avoids timeout race in `full flow: dry-run mode prevents execution` (test wraps command with `timeout 5`).

  ## Why
  - Some macOS setups (including Homebrew under `/usr/local`) failed immediately due to hardcoded `/opt/homebrew/bin/bash`.
  - Smoke/full-flow tests could fail intermittently due to version-check `git fetch` timing behavior.
  - `--dry-run` should not depend on network/update checks before reaching dry-run logic.

  ## Validation
  - `make lint` passes.
  - `./tests/run_tests.sh --all` passes.
  - `./tests/run_tests.sh --smoke` passes.