### PR TITLE
Update regex for matching root user in vulns.sh

### DIFF
--- a/modules/vulns.sh
+++ b/modules/vulns.sh
@@ -361,7 +361,7 @@ function lfi() {
                     -maxtime "$lfi_ffuf_maxtime"
                     -H "$HEADER"
                     -w "$lfi_wordlist"
-                    -mr "root:"
+                    -mr "root:x:"
                 )
                 local _lfi_parts
                 _lfi_parts=$(mktemp -d)


### PR DESCRIPTION
This may reduce a lot of false positives.

Earlier with `root:` got this URL as output

```
http://angular.testinvicti.com/main.fbe5fbd112683a8c2d92.bundle.js?firstName=Li4vLi4vLi4vLi4vLi4vLi4vZXRjL3Bhc3N3ZCUwMA==
```
on testing
```
curl -ks http://angular.testinvicti.com/main.fbe5fbd112683a8c2d92.bundle.js?firstName=Li4vLi4vLi4vLi4vLi4vLi4vZXRjL3Bhc3N3ZCUwMA== | js-beautify | grep "root:"
                            root: function(t) {
                    root: t,
```