### PR TITLE
Add Darkmoon (open source autonomous pentest platform)

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ reconFTW is packed with features to make reconnaissance thorough and efficient. 
 - **Google Analytics**: Identifies subdomains via Analytics IDs ([AnalyticsRelationships](https://github.com/Josue87/AnalyticsRelationships)).
 - **TLS Handshake**: Discovers subdomains via TLS ports ([tlsx](https://github.com/projectdiscovery/tlsx)).
 - **Recursive Search**: Performs recursive passive or bruteforce enumeration combined ([dsieve](https://github.com/trickest/dsieve)).
+- [Darkmoon](https://github.com/ASCIT31/Dark-Moon) - Open source (GPLv3) autonomous AI penetration testing platform: 50+ offensive tools across web, cloud, AD and Kubernetes, self-hosted, the model never receives your real IPs or credentials.
 - **Subdomain Takeover**: Detects vulnerable subdomains ([nuclei](https://github.com/projectdiscovery/nuclei) and [dnstake](https://github.com/pwnesia/dnstake)).
 - **DNS Zone Transfer**: Checks for misconfigured DNS zone transfers ([dig](https://linux.die.net/man/1/dig)).
 - **Cloud Buckets**: Identifies misconfigured cloud buckets and exposed storage assets ([S3Scanner](https://github.com/sa7mon/S3Scanner) and [cloud_enum](https://github.com/initstring/cloud_enum)).


### PR DESCRIPTION
Adds [Darkmoon](https://github.com/ASCIT31/Dark-Moon), an open-source (GPLv3) autonomous AI penetration testing platform across web, cloud, Active Directory and Kubernetes, self-hosted, with a local privacy gateway so the model never receives real IPs, hostnames or credentials. Thanks for maintaining this list.